### PR TITLE
[DRAFT] Security Vulnerability Upgrade for postgresql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1205,7 +1205,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.6.0</version>
+                <version>42.6.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Identified a security vulnerability of severity critical from postgresql and updated the fix for the same. 
```
Group id: org.postgresql
Artifact : postgresql
Issue for version : 42.6.0
```
Upgraded the version of postgresql to `42.6.1`. 

## Direct vulnerabilities: 
CVE-2024-1597

## Impact -: 
PostgreSQL JDBC Driver (PgJDBC) is vulnerable to SQL injection. A remote attacker could send specially crafted SQL statements when using the non-default connection property preferQueryMode=simple in combination with application code that has a vulnerable SQL that negates a parameter value, which could allow the attacker to view, add, modify or delete information in the back-end database.

```
== RELEASE NOTES ==   

Security Changes
Upgrade postgresql to 42.6.1 
PR: 5

