### PR TITLE
[DRAFT] Security vulnerability fix CVE-2021-28165, CVE-2021-22573

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -176,6 +176,10 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-protobuf-lite</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.oauth-client</groupId>
+                    <artifactId>google-oauth-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -269,6 +269,12 @@
             <groupId>com.facebook.airlift</groupId>
             <artifactId>http-server</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -200,6 +200,12 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>http-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -65,6 +65,12 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>event</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Identified  security vulnerability issues of severity high from jetty-io-9.4.14.v20181114.jar and google-oauth-client-1.31.2.jar. 

**Group id: org.eclipse.jetty**
Artifact : jetty-io
Issue for version : jetty-io-9.4.14.v20181114.jar
Direct vulnerabilities: [CVE-2021-28165](https://nvd.nist.gov/vuln/detail/cve-2021-28165)

Impact -:
Eclipse Jetty is vulnerable to a denial of service, caused by improper input validation. By sending a specially-crafted TLS frame, a remote attacker could exploit this vulnerability to cause CPU resources to reach to 100% usage.

-------------------------------------

**Group id: com.google.oauth-client**
Artifact : google-oauth-client
Issue for version : google-oauth-client-1.31.2.
Direct vulnerabilities:[CVE-2021-22573](https://github.com/advisories/GHSA-hw42-3568-wj87)

Impact-: 
Google APIs google-oauth-java-client could allow a remote attacker to bypass security restrictions, caused by no PKCE support implemented. By executing a specially-crafted application, an attacker could exploit this vulnerability to obtain the authorization code, and gain authorization to the protected resource.


```
== NO RELEASE NOTE ==
```


